### PR TITLE
fix: zero-initialize all bytes in  at startup to mitigate known issue…

### DIFF
--- a/begrun.c
+++ b/begrun.c
@@ -42,6 +42,7 @@
 void begrun(void)
 {
   struct global_data_all_processes all;
+  memset(&All, 0, sizeof(struct global_data_all_processes));
 #ifdef _OPENMP
   int tid;
 #endif


### PR DESCRIPTION
… with shared memory reads in systems running Rocky 8